### PR TITLE
Add container test job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,10 +3,33 @@ name: Nightly DNSpect Build
 on:
   schedule:
     - cron: '0 6 * * *'  # 12:00am MT / 6:00am UTC
+  pull_request:
   workflow_dispatch:
 
 jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build container image
+        run: docker build -t dnspect-test -f Containerfile .
+
+      - name: Verify installed tools
+        run: |
+          docker run --rm dnspect-test bash -c "\
+            dig -v && \
+            dnsrecon -h >/dev/null && \
+            amass -version && \
+            dmarc-cat --help >/dev/null && \
+            zonemaster-cli --version && \
+            test \"$(whoami)\" = dnspect \
+          "
+
   build_and_push:
+    needs: build_test
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- build container in CI for PRs
- run commands inside the container to verify installed tools
- keep nightly build-and-push job

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883ed6934c0832db7105fe36aa4d65f