### PR TITLE
Fix amass install path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,7 +37,9 @@ RUN cpanm --notest Zonemaster::LDNS && \
 
 # Install Amass
 RUN curl -L -o /tmp/amass.zip https://github.com/owasp-amass/amass/releases/latest/download/amass_linux_amd64.zip && \
-    unzip /tmp/amass.zip -d /usr/local/bin && rm /tmp/amass.zip
+    unzip /tmp/amass.zip -d /tmp && \
+    mv /tmp/amass_linux_amd64/amass /usr/local/bin/amass && \
+    rm -rf /tmp/amass_linux_amd64 /tmp/amass.zip
 
 # Install dnsperf & resperf from source
 RUN git clone https://github.com/DNS-OARC/dnsperf.git /opt/dnsperf && \


### PR DESCRIPTION
## Summary
- put amass binary directly in /usr/local/bin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883f11af388832d815f7dd48c1bebc5