### PR TITLE
Add build test job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,7 +6,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build DNSpect Image
+        run: |
+          docker build -t dnspect:test .
+
+      - name: Verify Tools
+        run: |
+          docker run --rm -v ${{ github.workspace }}/scripts/verify_tools.sh:/verify.sh:ro dnspect:test bash /verify.sh
+
   build_and_push:
+    needs: build_test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/verify_tools.sh
+++ b/scripts/verify_tools.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Verify critical tools exist and print their versions
+
+dig -v
+
+dnsrecon -h >/dev/null
+
+echo "dnsrecon available"
+
+amass -version
+
+zonemaster-cli --version
+
+dmarc-cat -h | head -n 1
+
+despf.sh -h | head -n 1


### PR DESCRIPTION
## Summary
- build container to run a quick tool verification
- keep nightly push job but make it dependent on the new build
- script to check core utilities

## Testing
- `shellcheck scripts/verify_tools.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883f982b1f0832daa4e1813d67d0f42