### PR TITLE
Add hadolint lint job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,7 +6,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Containerfile
+
   build_test:
+    needs: lint
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- add lint workflow job using hadolint/hadolint-action
- require build_test to wait for lint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883fae51cbc832d88119342c72e4db2